### PR TITLE
add Chunk + Fields API with selective decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,8 +66,9 @@ dependencies = [
 
 [[package]]
 name = "copc-streaming"
-version = "0.0.0-dev"
+version = "0.2.0-dev"
 dependencies = [
+ "bitflags",
  "byteorder",
  "las",
  "laz",
@@ -71,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "copc-temporal"
-version = "0.0.0-dev"
+version = "0.2.0-dev"
 dependencies = [
  "byteorder",
  "copc-streaming",
@@ -128,9 +135,8 @@ dependencies = [
 
 [[package]]
 name = "las"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d35a98a0bf1e7d30cd61899741af22f853110021be78175926cc870a39dfd"
+version = "0.9.11"
+source = "git+https://github.com/jacovdbergh/las-rs?rev=833cf7ae0d8e98edf41bca358dedb68297e23215#833cf7ae0d8e98edf41bca358dedb68297e23215"
 dependencies = [
  "byteorder",
  "chrono",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,188 @@
+# Roadmap
+
+Follow-up work after the `Chunk` / `Fields` landing. Each item lists what
+it does, what depends on upstream changes in `las-rs`, and where it lives.
+
+## Work we can do in-tree (no upstream changes)
+
+### 1. Two-pass selective decode for highly-selective spatial queries
+
+`reader::query_points` decodes every chunk with `Fields::ALL`. For very
+selective bounds queries on large chunks, a two-pass strategy could help:
+
+1. Fetch with `Fields::Z` (cheap — one layer)
+2. Compute `indices_in_bounds`
+3. If non-empty, refetch with `Fields::ALL` and materialize only matching indices
+
+Only a win when filters are highly selective _and_ chunks are large. The
+double decode hurts otherwise. Probably belongs as an opt-in strategy
+(`query_points_selective` or a config flag on the reader), not the default.
+
+Needs a benchmark harness to decide if it earns its complexity.
+
+### 2. Parallel chunk fetch
+
+`query_chunks` / `query_chunks_to_level` fetch chunks sequentially in a
+`for` loop. For workloads with many small chunks on IO-bound sources
+(HTTP, S3) this leaves a lot of throughput on the table.
+
+A `query_chunks_concurrent(bounds, fields, concurrency)` variant using
+`FuturesUnordered` would let callers express "fetch up to N chunks in
+flight." Obstacle: the current async design is non-`Send` (targets WASM
+single-threaded runtimes). `FuturesUnordered` needs the futures to be
+`'static` and ideally `Send`, which conflicts with references into
+`&self`. May require restructuring to take `Arc<Self>` or similar.
+
+Alternative: expose the building blocks (`visible_keys` +
+`fetch_chunk_with_source`) and let callers drive their own parallelism.
+That's already supported today, so "parallel query_chunks" is a
+convenience, not a capability gap.
+
+### 3. Integration test with a real COPC fixture
+
+None of the current tests exercise the actual LAZ decompression path, the
+`set_selection` wiring, or end-to-end fetch+filter+materialize. Unit tests
+cover `Chunk` construction, field guards, and index filters using
+synthetic `PointCloud`s built via `from_raw_bytes`, but the real decode
+path is untested.
+
+Commit a small `.copc.laz` fixture (a few thousand points, format 6 or 7,
+known field values) and add:
+
+- `fetch_chunk(&key, Fields::ALL)` end-to-end → expected point values
+- `fetch_chunk(&key, Fields::Z)` → positions match, other column accessors
+  return `None`
+- `fetch_chunk(&key, Fields::Z | Fields::GPS_TIME)` → gps times match
+- `query_points(&bounds)` round-trip
+- `TemporalCache::query_points` end-to-end (if the fixture has a temporal
+  EVLR, otherwise skip)
+
+Blocker: we need to either generate a fixture with `copc-rs` / PDAL or
+pull a small public sample.
+
+### 4. Selective-decode benchmark harness
+
+Once a fixture exists, a Criterion bench that reads it and runs
+`fetch_chunk` with different `Fields` masks would validate the
+selective-decode claims and let us track regressions. Per-chunk timing
+is more meaningful than full-file benchmarks because typical COPC chunks
+are ~64K–1M points.
+
+Report decode + materialization CPU separately; show the speedup factor
+as a function of mask size.
+
+## Upstream asks on `las-rs`
+
+None of these block the in-tree work above — everything listed here is a
+refinement that would let us delete local workarounds or unlock a cleaner
+API shape, not a blocker for any capability.
+
+Listed in rough order of "how much it would clean up our code."
+
+### A. `PointCloud::point_owned(i: usize) -> Result<Point>` (or equivalent)
+
+**What it unlocks:** `Chunk::points_at` currently vendors a
+`Cursor + raw::Point::read_from + Point::new` loop to materialize specific
+indices. It works but duplicates what `PointCloud::points()` already does
+internally, and walks a cursor sequentially for what is really random
+access.
+
+With a direct "give me an owned `Point` at index `i`" method on
+`PointCloud`, `points_at` becomes a one-liner:
+
+```rust
+indices.iter().map(|&i| self.cloud.point_owned(i as usize)).collect()
+```
+
+No cursor, no `raw::Point` import in copc, cleaner call site.
+
+**Upstream size:** ~15 lines on `PointCloud`, reusing the existing
+`raw::Point::read_from` path.
+
+**Alternatives:**
+- `impl From<(PointRef<'_>, &Format, &Vector<Transform>)> for Point` —
+  same effect, different ergonomics. `point_owned(i)` is simpler because
+  `PointCloud` already has the format and transforms cached.
+- `PointRef::to_point(&self, format: &Format, transforms: &Vector<Transform>) -> Point` —
+  inherent method on `PointRef`. Loses index-locality (PointRef doesn't
+  know its own index), so a caller still has to look up by index.
+
+### B. Fields tracking on `PointCloud` itself
+
+**What it unlocks:** today `Chunk` carries `Fields` and guards every
+column accessor. If callers reach into `chunk.cloud()` to use `PointCloud`
+accessors directly (for fields we don't expose on `Chunk`, or to use
+`x_raw` / `y_raw` etc.), they get valid-looking zero data for skipped
+fields — no panic, no None, just silent zeros. It's a footgun.
+
+Move the tracking upstream: `PointCloud::with_fields(Fields)` sets a mask,
+column accessors return `None` if the field isn't in the mask, `rgb()` /
+`gps_time()` / etc. combine the existing format check with the new field
+check. Then `Chunk::fields` can go away entirely — or become a pure
+passthrough.
+
+**Upstream size:** ~50-80 lines. Medium-sized but mechanical.
+
+**Coordination note:** `laz::DecompressionSelection` would also need to
+be visible in the las API surface to make the connection obvious. Might
+want to take a `DecompressionSelection` rather than a copc-specific
+`Fields` bitflag — `las-rs` already depends on `laz`.
+
+### C. Selective decode wired through `Reader::read_into_cloud`
+
+**What it unlocks:** `Reader::read_into_cloud(cloud, n)` currently always
+decodes every field. For non-copc users doing full-file reads with
+selective decode (e.g. someone computing bounds statistics on a multi-GB
+LAZ file who only needs x/y/z), they have no way to ask for a subset.
+
+Add `read_into_cloud_with(cloud, n, selection)` that passes the selection
+through to the laz backend's decompressor. Doesn't benefit copc directly
+(we drive the decompressor ourselves via `LayeredPointRecordDecompressor`)
+but it's the natural companion to making selective decode a first-class
+citizen of the `PointCloud` API.
+
+**Upstream size:** ~20 lines.
+
+### D. Missing column iterators on `PointCloud`
+
+**What it unlocks:** `PointCloud` exposes column iterators for `x`, `y`,
+`z`, `intensity`, `classification`, `return_number`, `number_of_returns`,
+`scan_angle_degrees`, `user_data`, `point_source_id`, `gps_time`, `rgb`,
+`nir`. Missing from the column API but present on `PointRef`:
+
+- `scanner_channel()`
+- Flag bits: `is_synthetic()`, `is_key_point()`, `is_withheld()`, `is_overlap()`
+- `waveform()` (full-waveform blob)
+- `extra_bytes()` (per-point extra bytes slice)
+
+All of these are legitimate LAS 1.4 fields that callers can already
+reach via `chunk.cloud().iter().map(|p| p.scanner_channel())` or
+equivalent; adding them to the column API is pure parity with `PointRef`.
+
+**Upstream size:** ~40 lines — mechanical, matches the existing pattern.
+
+### E. `rgb() -> [u16; 3]` instead of tuple
+
+**What it unlocks:** `PointCloud::rgb()` returns
+`Iterator<Item = (u16, u16, u16)>`. Arrays are more natural for GPU
+vertex buffer uploads (memcpy-friendly) and for callers that need
+indexed access. Minor ergonomic polish.
+
+**Upstream size:** either a breaking signature change or a parallel
+`rgb_array()` method.
+
+## Summary of "do in-tree" vs "needs upstream"
+
+| Item | Depends on upstream? |
+|---|---|
+| Two-pass selective decode | No |
+| Parallel chunk fetch | No (may need async restructure) |
+| Real-fixture integration tests | No (needs fixture file) |
+| Benchmark harness | No (needs fixture file) |
+| Simpler `Chunk::points_at` | Yes — A |
+| Remove field-guard duplication | Yes — B |
+| Missing column iterators | Yes — D |
+
+None of the in-tree follow-ups are blocked waiting on `las-rs`. Upstream
+changes would shrink the copc crate and eliminate a few footguns, but
+every capability is already achievable today.

--- a/copc-streaming/Cargo.toml
+++ b/copc-streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copc-streaming"
-version = "0.0.0-dev"
+version = "0.2.0-dev"
 edition = "2024"
 description = "Async streaming COPC (Cloud-Optimized Point Cloud) reader"
 license = "MIT"
@@ -12,7 +12,8 @@ readme = "../README.md"
 [dependencies]
 byteorder = "1"
 thiserror = "2"
-las = { version = "0.9", features = ["laz"] }
+bitflags = "2"
+las = { git = "https://github.com/jacovdbergh/las-rs", rev = "833cf7ae0d8e98edf41bca358dedb68297e23215", features = ["laz"] }
 laz = "0.12"
 
 [dev-dependencies]

--- a/copc-streaming/src/chunk.rs
+++ b/copc-streaming/src/chunk.rs
@@ -2,48 +2,274 @@
 
 use std::io::Cursor;
 
+use las::PointCloud;
 use laz::LazVlr;
 use laz::record::{LayeredPointRecordDecompressor, RecordDecompressor};
 
 use crate::byte_source::ByteSource;
 use crate::error::CopcError;
+use crate::fields::Fields;
 use crate::hierarchy::HierarchyEntry;
-use crate::types::VoxelKey;
+use crate::types::{Aabb, VoxelKey};
 
 /// A decompressed point data chunk.
+///
+/// A `Chunk` wraps a [`las::PointCloud`] along with the [`VoxelKey`] of the
+/// octree node it came from and the [`Fields`] mask that was used to decode
+/// it. Column accessors (`intensity`, `gps_time`, `rgb`, …) are guarded by
+/// the mask and return `None` for fields that were not decoded.
+///
+/// Construct via [`CopcStreamingReader::fetch_chunk`](crate::CopcStreamingReader::fetch_chunk)
+/// or [`CopcStreamingReader::query_chunks`](crate::CopcStreamingReader::query_chunks).
 #[non_exhaustive]
-pub struct DecompressedChunk {
+pub struct Chunk {
     /// The octree node this chunk belongs to.
     pub key: VoxelKey,
-    /// Raw decompressed point record bytes.
-    pub data: Vec<u8>,
-    /// Number of points in this chunk.
-    pub point_count: u32,
-    /// Size of a single point record in bytes.
-    pub point_record_length: u16,
+    /// Which fields were actually decompressed into this chunk.
+    pub fields: Fields,
+    cloud: PointCloud,
 }
 
-/// Fetch and decompress a single chunk.
-pub async fn fetch_and_decompress(
+impl Chunk {
+    /// Construct a `Chunk` from a [`VoxelKey`], a [`Fields`] mask, and a
+    /// [`las::PointCloud`].
+    ///
+    /// Normally you'll get chunks from
+    /// [`CopcStreamingReader::fetch_chunk`](crate::CopcStreamingReader::fetch_chunk);
+    /// this constructor exists for callers that drive their own
+    /// decompression pipeline (and for tests). The caller is responsible
+    /// for ensuring that `fields` accurately describes which LAZ layers
+    /// were decoded into `cloud` — otherwise the chunk's field guards will
+    /// hide columns that are actually valid, or (worse) expose columns
+    /// that contain zero'd bytes for skipped layers.
+    pub fn new(key: VoxelKey, fields: Fields, cloud: PointCloud) -> Self {
+        Self { key, fields, cloud }
+    }
+
+    /// Borrow the underlying [`las::PointCloud`] — an **unchecked** escape
+    /// hatch to the raw byte-level accessors in `las`.
+    ///
+    /// Use this when [`Chunk`]'s higher-level methods don't expose what
+    /// you need: `cloud.x_raw()`, `cloud.record_len()`, `cloud.raw_bytes()`,
+    /// `cloud.iter()` for zero-copy `PointRef` walks, etc.
+    ///
+    /// # ⚠ Field guards are bypassed
+    ///
+    /// Calling `cloud.rgb()`, `cloud.gps_time()`, `cloud.intensity()`, or
+    /// any `PointRef` accessor on bytes from this cloud does **not** check
+    /// whether the underlying layer was actually decoded. If you call one
+    /// of those on a chunk that was fetched without the corresponding
+    /// [`Fields`] flag, you get a valid-looking iterator of zeros.
+    ///
+    /// Prefer the [`Chunk`] methods ([`rgb`](Self::rgb),
+    /// [`gps_time`](Self::gps_time), etc.) — they return `None` when the
+    /// field is absent, making the hazard impossible to hit accidentally.
+    pub fn cloud(&self) -> &PointCloud {
+        &self.cloud
+    }
+
+    /// Number of points in this chunk.
+    pub fn point_count(&self) -> usize {
+        self.cloud.len()
+    }
+
+    /// Whether this chunk contains zero points.
+    pub fn is_empty(&self) -> bool {
+        self.cloud.is_empty()
+    }
+
+    /// Materialize every point in this chunk as an owned [`las::Point`].
+    ///
+    /// Returns [`CopcError::PartialDecode`] if this chunk was decoded with a
+    /// partial field mask — otherwise the resulting `las::Point`s would have
+    /// silently-zero values for skipped fields.
+    ///
+    /// This is the bridge from the column-oriented [`Chunk`] API back to
+    /// the simple `Vec<las::Point>` API. Prefer the column accessors
+    /// ([`intensity`](Self::intensity), [`gps_time`](Self::gps_time), …)
+    /// or `chunk.cloud().iter()` when you don't need owned values.
+    pub fn to_points(&self) -> Result<Vec<las::Point>, CopcError> {
+        if self.fields != Fields::ALL {
+            return Err(CopcError::PartialDecode(self.fields));
+        }
+        self.cloud.to_points().map_err(CopcError::Las)
+    }
+
+    /// Materialize `las::Point` values only at the given indices.
+    ///
+    /// Pair with [`indices_in_bounds`](Self::indices_in_bounds) or any
+    /// other index-producing filter to skip the materialization cost for
+    /// rejected points entirely:
+    ///
+    /// ```rust,ignore
+    /// let chunk = reader.fetch_chunk(&key, Fields::ALL).await?;
+    /// let indices = chunk.indices_in_bounds(&bounds).unwrap();
+    /// let points = chunk.points_at(&indices)?;
+    /// ```
+    ///
+    /// Returns [`CopcError::PartialDecode`] if the chunk was decoded with
+    /// a partial field mask, same as [`to_points`](Self::to_points).
+    pub fn points_at(&self, indices: &[u32]) -> Result<Vec<las::Point>, CopcError> {
+        if self.fields != Fields::ALL {
+            return Err(CopcError::PartialDecode(self.fields));
+        }
+        let record_len = self.cloud.record_len();
+        let format = self.cloud.format();
+        let transforms = self.cloud.transforms();
+        let bytes = self.cloud.raw_bytes();
+        indices
+            .iter()
+            .map(|&i| {
+                let start = i as usize * record_len;
+                let end = start + record_len;
+                let mut cursor = Cursor::new(&bytes[start..end]);
+                let raw = las::raw::Point::read_from(&mut cursor, format)?;
+                Ok(las::Point::new(raw, transforms))
+            })
+            .collect()
+    }
+
+    /// Iterate `(x, y, z)` world coordinates as `[f64; 3]`, or `None` if
+    /// [`Fields::Z`] was not set.
+    ///
+    /// `x` and `y` are always decoded on LAS 1.4 layered formats (they
+    /// share the always-on base layer with `return_number`,
+    /// `number_of_returns` and `scanner_channel`), but `z` is its own
+    /// skippable layer. A chunk without `Fields::Z` has zero bytes in the
+    /// `z` slots; returning `None` here keeps the footgun out of reach.
+    pub fn positions(&self) -> Option<impl Iterator<Item = [f64; 3]> + '_> {
+        if !self.fields.contains(Fields::Z) {
+            return None;
+        }
+        Some(self.cloud.iter().map(|p| [p.x(), p.y(), p.z()]))
+    }
+
+    /// Intensity column, or `None` if [`Fields::INTENSITY`] was not set
+    /// or the format does not include intensity.
+    pub fn intensity(&self) -> Option<impl Iterator<Item = u16> + '_> {
+        if !self.fields.contains(Fields::INTENSITY) {
+            return None;
+        }
+        Some(self.cloud.intensity())
+    }
+
+    /// Classification byte column, or `None` if [`Fields::CLASSIFICATION`]
+    /// was not set.
+    pub fn classification(&self) -> Option<impl Iterator<Item = u8> + '_> {
+        if !self.fields.contains(Fields::CLASSIFICATION) {
+            return None;
+        }
+        Some(self.cloud.classification())
+    }
+
+    /// Scan angle column in degrees, or `None` if [`Fields::SCAN_ANGLE`]
+    /// was not set.
+    pub fn scan_angle(&self) -> Option<impl Iterator<Item = f32> + '_> {
+        if !self.fields.contains(Fields::SCAN_ANGLE) {
+            return None;
+        }
+        Some(self.cloud.scan_angle_degrees())
+    }
+
+    /// User data byte column, or `None` if [`Fields::USER_DATA`] was not set.
+    pub fn user_data(&self) -> Option<impl Iterator<Item = u8> + '_> {
+        if !self.fields.contains(Fields::USER_DATA) {
+            return None;
+        }
+        Some(self.cloud.user_data())
+    }
+
+    /// Point source ID column, or `None` if [`Fields::POINT_SOURCE_ID`]
+    /// was not set.
+    pub fn point_source_id(&self) -> Option<impl Iterator<Item = u16> + '_> {
+        if !self.fields.contains(Fields::POINT_SOURCE_ID) {
+            return None;
+        }
+        Some(self.cloud.point_source_id())
+    }
+
+    /// GPS time column, or `None` if [`Fields::GPS_TIME`] was not set or
+    /// the format does not include GPS time.
+    pub fn gps_time(&self) -> Option<impl Iterator<Item = f64> + '_> {
+        if !self.fields.contains(Fields::GPS_TIME) {
+            return None;
+        }
+        self.cloud.gps_time()
+    }
+
+    /// RGB column, or `None` if [`Fields::RGB`] was not set or the format
+    /// does not include color.
+    pub fn rgb(&self) -> Option<impl Iterator<Item = (u16, u16, u16)> + '_> {
+        if !self.fields.contains(Fields::RGB) {
+            return None;
+        }
+        self.cloud.rgb()
+    }
+
+    /// NIR column, or `None` if [`Fields::NIR`] was not set or the format
+    /// does not include NIR.
+    pub fn nir(&self) -> Option<impl Iterator<Item = u16> + '_> {
+        if !self.fields.contains(Fields::NIR) {
+            return None;
+        }
+        self.cloud.nir()
+    }
+
+    /// Indices of points inside `bounds`, or `None` if [`Fields::Z`] was
+    /// not set.
+    ///
+    /// A 3D bounding-box intersection requires z, so a chunk without
+    /// `Fields::Z` can't produce meaningful results — `None` makes that
+    /// impossible to misuse. Pair the returned indices with any column
+    /// iterator on the chunk to produce a filtered view without
+    /// materializing `las::Point` values.
+    pub fn indices_in_bounds(&self, bounds: &Aabb) -> Option<Vec<u32>> {
+        let positions = self.positions()?;
+        Some(
+            positions
+                .enumerate()
+                .filter_map(|(i, [x, y, z])| {
+                    let inside = x >= bounds.min[0]
+                        && x <= bounds.max[0]
+                        && y >= bounds.min[1]
+                        && y <= bounds.max[1]
+                        && z >= bounds.min[2]
+                        && z <= bounds.max[2];
+                    inside.then_some(i as u32)
+                })
+                .collect(),
+        )
+    }
+}
+
+/// Fetch and decompress a single chunk, decoding only the layers requested
+/// by `fields`.
+pub(crate) async fn fetch_and_decompress(
     source: &impl ByteSource,
     entry: &HierarchyEntry,
     laz_vlr: &LazVlr,
-    point_record_length: u16,
-) -> Result<DecompressedChunk, CopcError> {
+    header: &las::Header,
+    fields: Fields,
+) -> Result<Chunk, CopcError> {
     let compressed = source
         .read_range(entry.offset, entry.byte_size as u64)
         .await?;
 
-    let decompressed_size = entry.point_count as usize * point_record_length as usize;
+    let format = *header.point_format();
+    let transforms = *header.transforms();
+
+    let record_len = format.len() as usize + format.extra_bytes as usize;
+    let decompressed_size = entry.point_count as usize * record_len;
     let mut decompressed = vec![0u8; decompressed_size];
 
-    decompress_copc_chunk(&compressed, &mut decompressed, laz_vlr)?;
+    decompress_copc_chunk(&compressed, &mut decompressed, laz_vlr, fields)?;
 
-    Ok(DecompressedChunk {
+    let cloud = PointCloud::from_raw_bytes(format, transforms, decompressed)?;
+
+    Ok(Chunk {
         key: entry.key,
-        data: decompressed,
-        point_count: entry.point_count,
-        point_record_length,
+        fields,
+        cloud,
     })
 }
 
@@ -53,59 +279,214 @@ pub async fn fetch_and_decompress(
 /// chunk table offset that standard LAZ files have. We use
 /// `LayeredPointRecordDecompressor` directly (the same approach as copc-rs)
 /// to bypass `LasZipDecompressor`'s chunk table handling.
+///
+/// `fields` is wired through `set_selection` so that LAZ skips arithmetic
+/// decoding of omitted layers. On LAS 1.4 layered formats (6/7/8 — the
+/// formats COPC mandates) this is a real CPU saving; on pre-1.4 formats
+/// the layered decompressor ignores the selection and decodes everything,
+/// but those aren't valid COPC point formats anyway.
 fn decompress_copc_chunk(
     compressed: &[u8],
     decompressed: &mut [u8],
     laz_vlr: &LazVlr,
+    fields: Fields,
 ) -> Result<(), CopcError> {
     let src = Cursor::new(compressed);
     let mut decompressor = LayeredPointRecordDecompressor::new(src);
     decompressor.set_fields_from(laz_vlr.items())?;
+    decompressor.set_selection(fields.to_laz_selection());
     decompressor.decompress_many(decompressed)?;
     Ok(())
 }
 
-/// Parse all points from a decompressed chunk into `las::Point` values.
-pub fn read_points(
-    chunk: &DecompressedChunk,
-    header: &las::Header,
-) -> Result<Vec<las::Point>, CopcError> {
-    read_points_range(chunk, header, 0..chunk.point_count)
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use las::point::Format;
+    use las::raw::point::{Flags, ScanAngle};
 
-/// Parse a sub-range of points from a decompressed chunk.
-///
-/// Only the points in `range` are parsed — bytes outside the range are skipped.
-/// Returns an error if the range extends beyond the chunk's point count.
-pub fn read_points_range(
-    chunk: &DecompressedChunk,
-    header: &las::Header,
-    range: std::ops::Range<u32>,
-) -> Result<Vec<las::Point>, CopcError> {
-    if range.end > chunk.point_count {
-        return Err(CopcError::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!(
-                "point range {}..{} exceeds chunk point count {}",
-                range.start, range.end, chunk.point_count
-            ),
-        )));
+    /// Build a `PointCloud` in format 7 (has gps_time + rgb) with `n` points
+    /// whose fields are a function of their index: `x = i, y = i + 1,
+    /// z = i + 2, intensity = 100 + i, gps_time = 1000 + i, rgb = (i, i, i)`.
+    /// Unit transforms (scale=1, offset=0) so raw == world for easy asserts.
+    fn build_test_cloud(n: i32) -> las::PointCloud {
+        let format = Format::new(7).unwrap();
+        let unit = las::Transform {
+            scale: 1.0,
+            offset: 0.0,
+        };
+        let transforms = las::Vector {
+            x: unit,
+            y: unit,
+            z: unit,
+        };
+        let mut buf = Vec::new();
+        for i in 0..n {
+            let rp = las::raw::Point {
+                x: i,
+                y: i + 1,
+                z: i + 2,
+                intensity: 100 + i as u16,
+                // Format 7 is extended -> ThreeByte flags.
+                flags: Flags::ThreeByte(0, 0, 2),
+                scan_angle: ScanAngle::Scaled(0),
+                user_data: 0,
+                point_source_id: 0,
+                gps_time: Some(1000.0 + f64::from(i)),
+                color: Some(las::Color {
+                    red: i as u16,
+                    green: i as u16,
+                    blue: i as u16,
+                }),
+                waveform: None,
+                nir: None,
+                extra_bytes: Vec::new(),
+            };
+            rp.write_to(&mut buf, &format).unwrap();
+        }
+        las::PointCloud::from_raw_bytes(format, transforms, buf).unwrap()
     }
 
-    let format = header.point_format();
-    let transforms = header.transforms();
-    let record_len = chunk.point_record_length as u64;
-
-    let start = (range.start as u64 * record_len) as usize;
-    let count = range.end.saturating_sub(range.start) as usize;
-
-    let mut cursor = Cursor::new(&chunk.data[start..]);
-    let mut points = Vec::with_capacity(count);
-
-    for _ in 0..count {
-        let raw = las::raw::Point::read_from(&mut cursor, format)?;
-        points.push(las::Point::new(raw, transforms));
+    fn make_chunk(cloud: las::PointCloud, fields: Fields) -> Chunk {
+        Chunk {
+            key: VoxelKey::ROOT,
+            fields,
+            cloud,
+        }
     }
 
-    Ok(points)
+    #[test]
+    fn point_count_and_empty() {
+        let cloud = build_test_cloud(5);
+        let chunk = make_chunk(cloud, Fields::ALL);
+        assert_eq!(chunk.point_count(), 5);
+        assert!(!chunk.is_empty());
+    }
+
+    #[test]
+    fn positions_iterate_correctly() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::ALL);
+        let positions: Vec<_> = chunk.positions().unwrap().collect();
+        assert_eq!(positions.len(), 3);
+        assert_eq!(positions[0], [0.0, 1.0, 2.0]);
+        assert_eq!(positions[2], [2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn positions_returns_none_without_z_field() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::empty());
+        assert!(chunk.positions().is_none());
+    }
+
+    #[test]
+    fn gps_time_column_guarded_by_fields() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::Z);
+        assert!(
+            chunk.gps_time().is_none(),
+            "GPS_TIME not in mask -> column should be None"
+        );
+    }
+
+    #[test]
+    fn gps_time_column_present_when_fields_allow() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::ALL);
+        let times: Vec<_> = chunk.gps_time().unwrap().collect();
+        assert_eq!(times, vec![1000.0, 1001.0, 1002.0]);
+    }
+
+    #[test]
+    fn rgb_column_guarded_by_fields() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::Z | Fields::GPS_TIME);
+        assert!(chunk.rgb().is_none());
+    }
+
+    #[test]
+    fn rgb_column_present_when_fields_allow() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::ALL);
+        let rgb: Vec<_> = chunk.rgb().unwrap().collect();
+        assert_eq!(rgb, vec![(0, 0, 0), (1, 1, 1), (2, 2, 2)]);
+    }
+
+    #[test]
+    fn intensity_column_guarded() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::Z);
+        assert!(chunk.intensity().is_none());
+        let chunk = make_chunk(build_test_cloud(3), Fields::Z | Fields::INTENSITY);
+        let intensities: Vec<_> = chunk.intensity().unwrap().collect();
+        assert_eq!(intensities, vec![100, 101, 102]);
+    }
+
+    #[test]
+    fn to_points_refuses_partial_fields() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::Z);
+        let r = chunk.to_points();
+        assert!(matches!(r, Err(CopcError::PartialDecode(_))));
+    }
+
+    #[test]
+    fn to_points_succeeds_with_all_fields() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::ALL);
+        let pts = chunk.to_points().unwrap();
+        assert_eq!(pts.len(), 3);
+        assert_eq!(pts[0].intensity, 100);
+        assert_eq!(pts[1].gps_time, Some(1001.0));
+    }
+
+    #[test]
+    fn points_at_materializes_subset() {
+        let chunk = make_chunk(build_test_cloud(5), Fields::ALL);
+        let pts = chunk.points_at(&[0, 2, 4]).unwrap();
+        assert_eq!(pts.len(), 3);
+        assert_eq!(pts[0].x, 0.0);
+        assert_eq!(pts[1].x, 2.0);
+        assert_eq!(pts[2].x, 4.0);
+        assert_eq!(pts[0].intensity, 100);
+        assert_eq!(pts[2].intensity, 104);
+    }
+
+    #[test]
+    fn points_at_refuses_partial_fields() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::Z);
+        let r = chunk.points_at(&[0, 1]);
+        assert!(matches!(r, Err(CopcError::PartialDecode(_))));
+    }
+
+    #[test]
+    fn points_at_empty_slice_returns_empty_vec() {
+        let chunk = make_chunk(build_test_cloud(3), Fields::ALL);
+        let pts = chunk.points_at(&[]).unwrap();
+        assert!(pts.is_empty());
+    }
+
+    #[test]
+    fn indices_in_bounds_filters_correctly() {
+        // Points: (0,1,2), (1,2,3), (2,3,4), (3,4,5), (4,5,6)
+        let chunk = make_chunk(build_test_cloud(5), Fields::ALL);
+        let bounds = Aabb {
+            min: [1.0, 0.0, 0.0],
+            max: [2.0, 10.0, 10.0],
+        };
+        // x in [1, 2]: indices 1 and 2.
+        assert_eq!(chunk.indices_in_bounds(&bounds).unwrap(), vec![1, 2]);
+    }
+
+    #[test]
+    fn indices_in_bounds_empty_when_outside() {
+        let chunk = make_chunk(build_test_cloud(5), Fields::ALL);
+        let bounds = Aabb {
+            min: [100.0, 100.0, 100.0],
+            max: [200.0, 200.0, 200.0],
+        };
+        assert!(chunk.indices_in_bounds(&bounds).unwrap().is_empty());
+    }
+
+    #[test]
+    fn indices_in_bounds_returns_none_without_z_field() {
+        let chunk = make_chunk(build_test_cloud(5), Fields::empty());
+        let bounds = Aabb {
+            min: [0.0, 0.0, 0.0],
+            max: [10.0, 10.0, 10.0],
+        };
+        assert!(chunk.indices_in_bounds(&bounds).is_none());
+    }
 }

--- a/copc-streaming/src/chunk.rs
+++ b/copc-streaming/src/chunk.rs
@@ -240,6 +240,81 @@ impl Chunk {
                 .collect(),
         )
     }
+
+    /// Decompress already-fetched compressed bytes into a [`Chunk`].
+    ///
+    /// Public counterpart to the sync inner that
+    /// [`CopcStreamingReader::fetch_chunks`](crate::CopcStreamingReader::fetch_chunks)
+    /// uses internally. Useful when the caller wants to issue the
+    /// [`ByteSource::read_range`](crate::ByteSource::read_range) on one
+    /// executor (e.g. the browser main thread) and run the CPU-bound
+    /// LAZ decompression on another (e.g. a Rayon worker pool).
+    ///
+    /// `compressed` must be exactly `entry.byte_size` bytes for the
+    /// chunk referenced by `entry.key`. `laz_vlr` and `header` come
+    /// from [`CopcStreamingReader::header`](crate::CopcStreamingReader::header)
+    /// and are immutable for the lifetime of the dataset, so a caller
+    /// can clone them out of the reader once and reuse them.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // Fetch on one thread, hand bytes to a worker for decode:
+    /// let entry = reader.get(&key).unwrap().clone();
+    /// let bytes = reader
+    ///     .source()
+    ///     .read_range(entry.offset, entry.byte_size as u64)
+    ///     .await?;
+    /// // ... move bytes to a worker thread ...
+    /// let chunk = Chunk::decompress(
+    ///     &bytes,
+    ///     &entry,
+    ///     reader.header().laz_vlr(),
+    ///     reader.header().las_header(),
+    ///     Fields::Z | Fields::RGB,
+    /// )?;
+    /// ```
+    pub fn decompress(
+        compressed: &[u8],
+        entry: &HierarchyEntry,
+        laz_vlr: &LazVlr,
+        header: &las::Header,
+        fields: Fields,
+    ) -> Result<Self, CopcError> {
+        decompress_chunk(compressed, entry, laz_vlr, header, fields)
+    }
+}
+
+/// Decompress already-fetched compressed bytes into a [`Chunk`].
+///
+/// This is the sync counterpart to [`fetch_and_decompress`] — it skips
+/// the I/O step and works directly on a `&[u8]` buffer. Used by
+/// [`CopcStreamingReader::fetch_chunks`](crate::CopcStreamingReader::fetch_chunks)
+/// to decompress a batch of chunks that were fetched in a single
+/// [`ByteSource::read_ranges`] call.
+pub(crate) fn decompress_chunk(
+    compressed: &[u8],
+    entry: &HierarchyEntry,
+    laz_vlr: &LazVlr,
+    header: &las::Header,
+    fields: Fields,
+) -> Result<Chunk, CopcError> {
+    let format = *header.point_format();
+    let transforms = *header.transforms();
+
+    let record_len = format.len() as usize + format.extra_bytes as usize;
+    let decompressed_size = entry.point_count as usize * record_len;
+    let mut decompressed = vec![0u8; decompressed_size];
+
+    decompress_copc_chunk(compressed, &mut decompressed, laz_vlr, fields)?;
+
+    let cloud = PointCloud::from_raw_bytes(format, transforms, decompressed)?;
+
+    Ok(Chunk {
+        key: entry.key,
+        fields,
+        cloud,
+    })
 }
 
 /// Fetch and decompress a single chunk, decoding only the layers requested
@@ -254,23 +329,7 @@ pub(crate) async fn fetch_and_decompress(
     let compressed = source
         .read_range(entry.offset, entry.byte_size as u64)
         .await?;
-
-    let format = *header.point_format();
-    let transforms = *header.transforms();
-
-    let record_len = format.len() as usize + format.extra_bytes as usize;
-    let decompressed_size = entry.point_count as usize * record_len;
-    let mut decompressed = vec![0u8; decompressed_size];
-
-    decompress_copc_chunk(&compressed, &mut decompressed, laz_vlr, fields)?;
-
-    let cloud = PointCloud::from_raw_bytes(format, transforms, decompressed)?;
-
-    Ok(Chunk {
-        key: entry.key,
-        fields,
-        cloud,
-    })
+    decompress_chunk(&compressed, entry, laz_vlr, header, fields)
 }
 
 /// Decompress a single COPC chunk.

--- a/copc-streaming/src/chunk.rs
+++ b/copc-streaming/src/chunk.rs
@@ -302,7 +302,13 @@ pub(crate) fn decompress_chunk(
     let format = *header.point_format();
     let transforms = *header.transforms();
 
-    let record_len = format.len() as usize + format.extra_bytes as usize;
+    // `Format::len()` already includes `extra_bytes`, so the on-disk record
+    // length is exactly `format.len()`. Adding `extra_bytes` again double-counts
+    // them: for files with extra dimensions the output buffer is oversized, the
+    // layered LAZ decoder keeps reading to fill the surplus, overruns the chunk,
+    // and `read_exact` fails with "failed to fill whole buffer". Files with
+    // `extra_bytes == 0` were unaffected, which is why only some COPC failed.
+    let record_len = format.len() as usize;
     let decompressed_size = entry.point_count as usize * record_len;
     let mut decompressed = vec![0u8; decompressed_size];
 

--- a/copc-streaming/src/error.rs
+++ b/copc-streaming/src/error.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+use crate::fields::Fields;
+
 /// Errors that can occur when reading a COPC file.
 #[derive(Debug, Error)]
 pub enum CopcError {
@@ -33,6 +35,16 @@ pub enum CopcError {
     /// The requested node is not in the loaded hierarchy.
     #[error("node not found in hierarchy: {0:?}")]
     NodeNotFound(crate::types::VoxelKey),
+
+    /// Attempted to materialize `las::Point` values from a chunk that was
+    /// decoded with a partial field mask.
+    ///
+    /// A partially-decoded chunk leaves skipped field bytes as zeros in the
+    /// backing buffer, so producing `Point` values from it would silently
+    /// yield wrong data for those fields. Refetch the chunk with `Fields::ALL`
+    /// or use the column-level accessors on [`Chunk`](crate::Chunk) instead.
+    #[error("cannot materialize points from partially-decoded chunk (fields: {0:?})")]
+    PartialDecode(Fields),
 
     /// Custom error from a [`ByteSource`](crate::ByteSource) implementation.
     #[error("byte source error: {0}")]

--- a/copc-streaming/src/fields.rs
+++ b/copc-streaming/src/fields.rs
@@ -1,0 +1,208 @@
+//! Field selection for selective LAZ decompression.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Which point fields to decompress.
+    ///
+    /// On LAS 1.4 layered point formats (6, 7, 8 — the formats COPC mandates),
+    /// LAZ decompression is organized as independent per-field byte layers.
+    /// Omitted fields skip arithmetic decoding of their layer entirely, which
+    /// is a direct CPU saving proportional to the number of layers dropped.
+    ///
+    /// The following fields are always decoded regardless of the mask because
+    /// they share a single base layer: `x`, `y`, `return_number`,
+    /// `number_of_returns`, and `scanner_channel`. They are "free" in the
+    /// sense that you cannot skip them. The minimum mask that still gives
+    /// full 3D geometry is `Fields::Z` (just the Z layer on top of the
+    /// always-on base).
+    ///
+    /// When a field is not present in the mask, its bytes in the decompressed
+    /// chunk remain zero. Calling a column accessor for a skipped field on a
+    /// [`Chunk`](crate::Chunk) returns `None`, so downstream code cannot
+    /// silently read stale zeros.
+    ///
+    /// # Composing masks
+    ///
+    /// Use bitwise `|` to combine flags and [`Fields::empty`] /
+    /// [`Fields::ALL`] as the extremes:
+    ///
+    /// ```
+    /// use copc_streaming::Fields;
+    ///
+    /// // Geometry only.
+    /// let geometry = Fields::Z;
+    ///
+    /// // Geometry + color.
+    /// let geometry_rgb = Fields::Z | Fields::RGB;
+    ///
+    /// // Geometry + gps time.
+    /// let geometry_time = Fields::Z | Fields::GPS_TIME;
+    ///
+    /// // Full decode — required if you want `Chunk::to_points()` or
+    /// // `Chunk::points_at()` to succeed.
+    /// let everything = Fields::ALL;
+    ///
+    /// // `Fields::empty()` decodes only the always-on base layer:
+    /// // x, y, return_number, number_of_returns, scanner_channel.
+    /// let bare = Fields::empty();
+    /// ```
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+    pub struct Fields: u32 {
+        /// Z coordinate.
+        const Z               = 1 << 0;
+        /// Intensity (return strength).
+        const INTENSITY       = 1 << 1;
+        /// Classification code.
+        const CLASSIFICATION  = 1 << 2;
+        /// Flag bits (synthetic / key-point / withheld / overlap, etc.).
+        const FLAGS           = 1 << 3;
+        /// Scan angle.
+        const SCAN_ANGLE      = 1 << 4;
+        /// User data byte.
+        const USER_DATA       = 1 << 5;
+        /// Point source ID.
+        const POINT_SOURCE_ID = 1 << 6;
+        /// GPS time.
+        const GPS_TIME        = 1 << 7;
+        /// RGB color triple.
+        const RGB             = 1 << 8;
+        /// Near-infrared value.
+        const NIR             = 1 << 9;
+        /// Full-waveform packet data.
+        const WAVEPACKET      = 1 << 10;
+        /// Extra bytes region.
+        const EXTRA_BYTES     = 1 << 11;
+
+        /// Decode every field. The only mask that lets a chunk be materialized
+        /// back into `las::Point` values via [`Chunk::to_points`](crate::Chunk::to_points).
+        const ALL = Self::Z.bits()
+                  | Self::INTENSITY.bits()
+                  | Self::CLASSIFICATION.bits()
+                  | Self::FLAGS.bits()
+                  | Self::SCAN_ANGLE.bits()
+                  | Self::USER_DATA.bits()
+                  | Self::POINT_SOURCE_ID.bits()
+                  | Self::GPS_TIME.bits()
+                  | Self::RGB.bits()
+                  | Self::NIR.bits()
+                  | Self::WAVEPACKET.bits()
+                  | Self::EXTRA_BYTES.bits();
+    }
+}
+
+impl Fields {
+    /// Build a [`laz::DecompressionSelection`] matching this mask.
+    ///
+    /// Uses the laz builder API (`xy_returns_channel()` + `decompress_*`)
+    /// instead of a raw bit-cast, so the public `Fields` layout is not
+    /// coupled to laz's internal representation.
+    pub(crate) fn to_laz_selection(self) -> laz::DecompressionSelection {
+        let mut sel = laz::DecompressionSelection::xy_returns_channel();
+        if self.contains(Fields::Z) {
+            sel = sel.decompress_z();
+        }
+        if self.contains(Fields::INTENSITY) {
+            sel = sel.decompress_intensity();
+        }
+        if self.contains(Fields::CLASSIFICATION) {
+            sel = sel.decompress_classification();
+        }
+        if self.contains(Fields::FLAGS) {
+            sel = sel.decompress_flags();
+        }
+        if self.contains(Fields::SCAN_ANGLE) {
+            sel = sel.decompress_scan_angle();
+        }
+        if self.contains(Fields::USER_DATA) {
+            sel = sel.decompress_user_data();
+        }
+        if self.contains(Fields::POINT_SOURCE_ID) {
+            sel = sel.decompress_point_source_id();
+        }
+        if self.contains(Fields::GPS_TIME) {
+            sel = sel.decompress_gps_time();
+        }
+        if self.contains(Fields::RGB) {
+            sel = sel.decompress_rgb();
+        }
+        if self.contains(Fields::NIR) {
+            sel = sel.decompress_nir();
+        }
+        if self.contains(Fields::WAVEPACKET) {
+            sel = sel.decompress_wavepacket();
+        }
+        if self.contains(Fields::EXTRA_BYTES) {
+            sel = sel.decompress_extra_bytes();
+        }
+        sel
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_contains_every_layer() {
+        assert!(Fields::ALL.contains(Fields::Z));
+        assert!(Fields::ALL.contains(Fields::INTENSITY));
+        assert!(Fields::ALL.contains(Fields::CLASSIFICATION));
+        assert!(Fields::ALL.contains(Fields::FLAGS));
+        assert!(Fields::ALL.contains(Fields::SCAN_ANGLE));
+        assert!(Fields::ALL.contains(Fields::USER_DATA));
+        assert!(Fields::ALL.contains(Fields::POINT_SOURCE_ID));
+        assert!(Fields::ALL.contains(Fields::GPS_TIME));
+        assert!(Fields::ALL.contains(Fields::RGB));
+        assert!(Fields::ALL.contains(Fields::NIR));
+        assert!(Fields::ALL.contains(Fields::WAVEPACKET));
+        assert!(Fields::ALL.contains(Fields::EXTRA_BYTES));
+    }
+
+    #[test]
+    fn composition() {
+        let f = Fields::Z | Fields::GPS_TIME;
+        assert!(f.contains(Fields::Z));
+        assert!(f.contains(Fields::GPS_TIME));
+        assert!(!f.contains(Fields::RGB));
+        assert!(!f.contains(Fields::INTENSITY));
+    }
+
+    #[test]
+    fn empty_mask_has_no_layers_set() {
+        let sel = Fields::empty().to_laz_selection();
+        assert!(!sel.should_decompress_z());
+        assert!(!sel.should_decompress_classification());
+        assert!(!sel.should_decompress_intensity());
+        assert!(!sel.should_decompress_gps_time());
+        assert!(!sel.should_decompress_rgb());
+    }
+
+    #[test]
+    fn selective_mask_enables_only_requested_layers() {
+        let sel = (Fields::Z | Fields::GPS_TIME).to_laz_selection();
+        assert!(sel.should_decompress_z());
+        assert!(sel.should_decompress_gps_time());
+        assert!(!sel.should_decompress_rgb());
+        assert!(!sel.should_decompress_intensity());
+        assert!(!sel.should_decompress_classification());
+        assert!(!sel.should_decompress_nir());
+    }
+
+    #[test]
+    fn all_mask_enables_every_layer() {
+        let sel = Fields::ALL.to_laz_selection();
+        assert!(sel.should_decompress_z());
+        assert!(sel.should_decompress_intensity());
+        assert!(sel.should_decompress_classification());
+        assert!(sel.should_decompress_flags());
+        assert!(sel.should_decompress_scan_angle());
+        assert!(sel.should_decompress_user_data());
+        assert!(sel.should_decompress_point_source_id());
+        assert!(sel.should_decompress_gps_time());
+        assert!(sel.should_decompress_rgb());
+        assert!(sel.should_decompress_nir());
+        assert!(sel.should_decompress_wavepacket());
+        assert!(sel.should_decompress_extra_bytes());
+    }
+}

--- a/copc-streaming/src/hierarchy.rs
+++ b/copc-streaming/src/hierarchy.rs
@@ -264,6 +264,7 @@ mod tests {
     use super::*;
     use byteorder::WriteBytesExt;
 
+    #[allow(clippy::too_many_arguments)]
     fn write_hierarchy_entry(
         buf: &mut Vec<u8>,
         level: i32,

--- a/copc-streaming/src/hierarchy.rs
+++ b/copc-streaming/src/hierarchy.rs
@@ -198,6 +198,19 @@ impl HierarchyCache {
         !self.pending_pages.is_empty()
     }
 
+    /// Iterate the [`VoxelKey`]s anchoring the currently-pending hierarchy
+    /// pages. A pending page is a sub-tree whose entries live in a separate
+    /// page in the file that hasn't been fetched yet. The anchor key is the
+    /// node that owns the page pointer; resolving the page populates that
+    /// node's subtree.
+    ///
+    /// Useful to consumers that want to surface unloaded subtrees as
+    /// "proxy" nodes in their own data structure, then trigger
+    /// [`Self::load_pages_for_bounds`] / equivalent on demand.
+    pub fn pending_page_keys(&self) -> impl Iterator<Item = VoxelKey> + '_ {
+        self.pending_pages.iter().map(|p| p.key)
+    }
+
     /// Look up a hierarchy entry by key.
     pub fn get(&self, key: &VoxelKey) -> Option<&HierarchyEntry> {
         self.entries.get(key)

--- a/copc-streaming/src/lib.rs
+++ b/copc-streaming/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! // One call: loads hierarchy, fetches chunks, filters points by bounds.
 //! let points = reader.query_points(&my_query_box).await?;
-//! // each `point` has .x, .y, .z, .gps_time, .color, etc.
+//! // each `las::Point` has .x, .y, .z, .gps_time, .color, etc.
 //! ```
 //!
 //! # With LOD control
@@ -27,24 +27,46 @@
 //! let points = reader.query_points_to_level(&my_query_box, level).await?;
 //! ```
 //!
-//! # Low-level access
+//! # Fast path: select only the fields you need
 //!
-//! For full control over hierarchy loading and chunk processing:
+//! The [`query_points`](CopcStreamingReader::query_points) family decodes
+//! every field and materializes `las::Point` values. For hot paths,
+//! [`query_chunks`](CopcStreamingReader::query_chunks) returns [`Chunk`]s
+//! with zero-copy column access and lets you pick which LAZ layers to
+//! decode at all. Omitted layers skip arithmetic decoding entirely.
 //!
 //! ```rust,ignore
-//! let mut reader = CopcStreamingReader::open(
-//!     FileSource::open("points.copc.laz")?,
-//! ).await?;
+//! use copc_streaming::{CopcStreamingReader, FileSource, Fields};
 //!
-//! let root_bounds = reader.copc_info().root_bounds();
-//! reader.load_hierarchy_for_bounds(&my_query_box).await?;
+//! let level = reader.copc_info().level_for_resolution(0.5);
+//! let chunks = reader
+//!     .query_chunks_to_level(&my_query_box, level, Fields::Z | Fields::RGB)
+//!     .await?;
 //!
-//! for (key, entry) in reader.entries() {
-//!     if entry.point_count == 0 { continue; }
-//!     if !key.bounds(&root_bounds).intersects(&my_query_box) { continue; }
+//! for chunk in &chunks {
+//!     // `unwrap` is safe — we asked for Z and RGB so the chunk has them.
+//!     let indices = chunk.indices_in_bounds(&my_query_box).unwrap();
+//!     let rgb = chunk.rgb().unwrap();
+//!     let positions = chunk.positions().unwrap();
+//!     for (pos, rgb) in positions.zip(rgb) {
+//!         // ...
+//!     }
+//! }
+//! ```
 //!
-//!     let chunk = reader.fetch_chunk(key).await?;
-//!     let points = reader.read_points_in_bounds(&chunk, &my_query_box)?;
+//! # Low-level access
+//!
+//! For full control over hierarchy loading and fetch parallelism, combine
+//! [`load_hierarchy_for_bounds_to_level`](CopcStreamingReader::load_hierarchy_for_bounds_to_level),
+//! [`visible_keys`](CopcStreamingReader::visible_keys), and
+//! [`fetch_chunk`](CopcStreamingReader::fetch_chunk):
+//!
+//! ```rust,ignore
+//! reader.load_hierarchy_for_bounds_to_level(&my_query_box, level).await?;
+//! for key in reader.visible_keys(&my_query_box, Some(level)) {
+//!     let chunk = reader.fetch_chunk(&key, Fields::Z | Fields::GPS_TIME).await?;
+//!     let times = chunk.gps_time().unwrap();
+//!     // ... drive your own parallelism / cancellation / prioritization
 //! }
 //! ```
 //!
@@ -94,6 +116,7 @@
 mod byte_source;
 mod chunk;
 mod error;
+mod fields;
 mod file_source;
 mod header;
 mod hierarchy;
@@ -101,13 +124,16 @@ mod reader;
 mod types;
 
 pub use byte_source::ByteSource;
-pub use chunk::{DecompressedChunk, fetch_and_decompress};
+pub use chunk::Chunk;
 pub use error::CopcError;
+pub use fields::Fields;
 pub use file_source::FileSource;
 pub use header::{CopcHeader, CopcInfo};
 pub use hierarchy::{HierarchyCache, HierarchyEntry};
-pub use reader::{CopcStreamingReader, filter_points_by_bounds};
+pub use reader::CopcStreamingReader;
 pub use types::{Aabb, VoxelKey};
 
-/// Re-export `las::Point` — the point type returned by all read methods.
-pub use las::Point;
+// Re-exports of the handful of `las` types that appear in this crate's
+// public API. Users who only consume the types we return don't need to
+// add `las` as a direct dependency.
+pub use las::{Point, PointCloud, PointRef};

--- a/copc-streaming/src/reader.rs
+++ b/copc-streaming/src/reader.rs
@@ -1,8 +1,9 @@
 //! High-level streaming COPC reader.
 
 use crate::byte_source::ByteSource;
-use crate::chunk::{self, DecompressedChunk};
+use crate::chunk::{self, Chunk};
 use crate::error::CopcError;
+use crate::fields::Fields;
 use crate::header::{self, CopcHeader, CopcInfo};
 use crate::hierarchy::{HierarchyCache, HierarchyEntry};
 use crate::types::VoxelKey;
@@ -145,11 +146,23 @@ impl<S: ByteSource> CopcStreamingReader<S> {
             .await
     }
 
-    // --- Point data ---
+    // ==================== Fast API (tier 2) ====================
+    //
+    // Returns `Chunk`s with zero-copy column access. Caller picks which
+    // fields to decode, walks columns directly, and decides when to
+    // materialize `las::Point` values (if ever).
 
-    /// Fetch and decompress a single point chunk.
-    pub async fn fetch_chunk(&self, key: &VoxelKey) -> Result<DecompressedChunk, CopcError> {
-        self.fetch_chunk_with_source(&self.source, key).await
+    /// Fetch and decompress a single chunk, decoding only the fields in
+    /// `fields`.
+    ///
+    /// On LAS 1.4 layered formats (6/7/8 — the formats COPC mandates) this
+    /// is a real CPU saving proportional to the number of skipped layers.
+    /// Fields listed in [`Fields`] map directly to LAZ layer-level
+    /// `DecompressionSelection` and the omitted layers are not arithmetically
+    /// decoded at all.
+    pub async fn fetch_chunk(&self, key: &VoxelKey, fields: Fields) -> Result<Chunk, CopcError> {
+        self.fetch_chunk_with_source(&self.source, key, fields)
+            .await
     }
 
     /// Fetch and decompress a point chunk using an external byte source.
@@ -161,91 +174,131 @@ impl<S: ByteSource> CopcStreamingReader<S> {
         &self,
         source: &impl ByteSource,
         key: &VoxelKey,
-    ) -> Result<DecompressedChunk, CopcError> {
+        fields: Fields,
+    ) -> Result<Chunk, CopcError> {
         let entry = self
             .hierarchy
             .get(key)
             .ok_or(CopcError::NodeNotFound(*key))?;
-        let point_record_length = self.header.las_header.point_format().len()
-            + self.header.las_header.point_format().extra_bytes;
-        chunk::fetch_and_decompress(source, entry, &self.header.laz_vlr, point_record_length).await
+        chunk::fetch_and_decompress(
+            source,
+            entry,
+            &self.header.laz_vlr,
+            &self.header.las_header,
+            fields,
+        )
+        .await
     }
 
-    /// Parse all points from a decompressed chunk.
-    pub fn read_points(&self, chunk: &DecompressedChunk) -> Result<Vec<las::Point>, CopcError> {
-        chunk::read_points(chunk, &self.header.las_header)
-    }
-
-    /// Parse a sub-range of points from a decompressed chunk.
+    /// Keys in the currently-loaded hierarchy whose subtree intersects
+    /// `bounds` and whose level is at most `max_level` (if provided).
     ///
-    /// Only the points in `range` are parsed — bytes outside the range are skipped.
-    /// Pair with `NodeTemporalEntry::estimate_point_range` from the `copc-temporal`
-    /// crate to read only the points that fall within a time window.
-    pub fn read_points_range(
-        &self,
-        chunk: &DecompressedChunk,
-        range: std::ops::Range<u32>,
-    ) -> Result<Vec<las::Point>, CopcError> {
-        chunk::read_points_range(chunk, &self.header.las_header, range)
-    }
-
-    /// Parse all points from a chunk, keeping only those inside `bounds`.
-    pub fn read_points_in_bounds(
-        &self,
-        chunk: &DecompressedChunk,
-        bounds: &crate::types::Aabb,
-    ) -> Result<Vec<las::Point>, CopcError> {
-        let points = chunk::read_points(chunk, &self.header.las_header)?;
-        Ok(filter_points_by_bounds(points, bounds))
-    }
-
-    /// Parse a sub-range of points, keeping only those inside `bounds`.
-    ///
-    /// Combines temporal range estimation with spatial filtering: first only
-    /// the points in `range` are decompressed, then points outside `bounds`
-    /// are discarded.
-    pub fn read_points_range_in_bounds(
-        &self,
-        chunk: &DecompressedChunk,
-        range: std::ops::Range<u32>,
-        bounds: &crate::types::Aabb,
-    ) -> Result<Vec<las::Point>, CopcError> {
-        let points = chunk::read_points_range(chunk, &self.header.las_header, range)?;
-        Ok(filter_points_by_bounds(points, bounds))
-    }
-
-    // --- High-level queries ---
-
-    /// Load hierarchy and return all points inside `bounds`.
-    ///
-    /// This is the simplest way to query a spatial region. It loads the
-    /// hierarchy pages that overlap `bounds`, fetches and decompresses
-    /// matching chunks, and returns only the points inside the bounding box.
+    /// Use this to drive your own fetch loop — for parallelism, cancellation,
+    /// prioritization, or streaming:
     ///
     /// ```rust,ignore
-    /// let points = reader.query_points(&my_query_box).await?;
+    /// reader.load_hierarchy_for_bounds_to_level(&bbox, lod).await?;
+    /// for key in reader.visible_keys(&bbox, Some(lod)) {
+    ///     let chunk = reader.fetch_chunk(&key, Fields::Z | Fields::RGB).await?;
+    ///     // ...
+    /// }
     /// ```
+    pub fn visible_keys(
+        &self,
+        bounds: &crate::types::Aabb,
+        max_level: Option<i32>,
+    ) -> Vec<VoxelKey> {
+        let root_bounds = self.header.copc_info.root_bounds();
+        self.hierarchy
+            .iter()
+            .filter(|(k, e)| {
+                e.point_count > 0
+                    && max_level.is_none_or(|lvl| k.level <= lvl)
+                    && k.bounds(&root_bounds).intersects(bounds)
+            })
+            .map(|(k, _)| *k)
+            .collect()
+    }
+
+    /// Load hierarchy for `bounds`, fetch every intersecting chunk, and
+    /// return them.
+    ///
+    /// Convenience wrapper over [`load_hierarchy_for_bounds`](Self::load_hierarchy_for_bounds),
+    /// [`visible_keys`](Self::visible_keys), and [`fetch_chunk`](Self::fetch_chunk)
+    /// in a sequential loop. For parallel fetches, cancellation, or
+    /// prioritization, use those building blocks directly.
+    pub async fn query_chunks(
+        &mut self,
+        bounds: &crate::types::Aabb,
+        fields: Fields,
+    ) -> Result<Vec<Chunk>, CopcError> {
+        self.load_hierarchy_for_bounds(bounds).await?;
+        let keys = self.visible_keys(bounds, None);
+        let mut chunks = Vec::with_capacity(keys.len());
+        for key in keys {
+            chunks.push(self.fetch_chunk(&key, fields).await?);
+        }
+        Ok(chunks)
+    }
+
+    /// Same as [`query_chunks`](Self::query_chunks) but limits the octree
+    /// depth to `max_level`.
+    pub async fn query_chunks_to_level(
+        &mut self,
+        bounds: &crate::types::Aabb,
+        max_level: i32,
+        fields: Fields,
+    ) -> Result<Vec<Chunk>, CopcError> {
+        self.load_hierarchy_for_bounds_to_level(bounds, max_level)
+            .await?;
+        let keys = self.visible_keys(bounds, Some(max_level));
+        let mut chunks = Vec::with_capacity(keys.len());
+        for key in keys {
+            chunks.push(self.fetch_chunk(&key, fields).await?);
+        }
+        Ok(chunks)
+    }
+
+    // ==================== Simple API (tier 1) ====================
+    //
+    // One-line entry points for scripts, tests, and prototypes. Always
+    // decodes every field and materializes `las::Point` values. Thin
+    // wrappers over the fast API — no duplicate read paths.
+
+    /// Fetch, decompress, and materialize every point in one chunk as
+    /// owned [`las::Point`] values.
+    ///
+    /// Equivalent to `fetch_chunk(key, Fields::ALL).await?.to_points()?`.
+    /// Prefer [`fetch_chunk`](Self::fetch_chunk) for performance-sensitive
+    /// code paths.
+    pub async fn fetch_points(&self, key: &VoxelKey) -> Result<Vec<las::Point>, CopcError> {
+        self.fetch_chunk(key, Fields::ALL).await?.to_points()
+    }
+
+    /// Load hierarchy for `bounds`, fetch all intersecting chunks, and
+    /// return the points inside `bounds`.
+    ///
+    /// Thin wrapper over [`query_chunks`](Self::query_chunks) with
+    /// `Fields::ALL`. Decodes everything and materializes; prefer
+    /// `query_chunks` when you only need a subset of fields or want to
+    /// walk points column-by-column.
     pub async fn query_points(
         &mut self,
         bounds: &crate::types::Aabb,
     ) -> Result<Vec<las::Point>, CopcError> {
-        self.load_hierarchy_for_bounds(bounds).await?;
-        let root_bounds = self.header.copc_info.root_bounds();
-
-        let keys: Vec<VoxelKey> = self
-            .hierarchy
-            .iter()
-            .filter(|(k, e)| e.point_count > 0 && k.bounds(&root_bounds).intersects(bounds))
-            .map(|(k, _)| *k)
-            .collect();
-
-        let mut all_points = Vec::new();
-        for key in keys {
-            let chunk = self.fetch_chunk(&key).await?;
-            let points = self.read_points_in_bounds(&chunk, bounds)?;
-            all_points.extend(points);
+        let chunks = self.query_chunks(bounds, Fields::ALL).await?;
+        let mut out = Vec::new();
+        for chunk in &chunks {
+            // `indices_in_bounds` on an `ALL`-decoded chunk always returns Some.
+            let indices = chunk
+                .indices_in_bounds(bounds)
+                .expect("Fields::ALL includes Fields::Z");
+            if indices.is_empty() {
+                continue;
+            }
+            out.extend(chunk.points_at(&indices)?);
         }
-        Ok(all_points)
+        Ok(out)
     }
 
     /// Load hierarchy to `max_level` and return all points inside `bounds`.
@@ -262,45 +315,19 @@ impl<S: ByteSource> CopcStreamingReader<S> {
         bounds: &crate::types::Aabb,
         max_level: i32,
     ) -> Result<Vec<las::Point>, CopcError> {
-        self.load_hierarchy_for_bounds_to_level(bounds, max_level)
+        let chunks = self
+            .query_chunks_to_level(bounds, max_level, Fields::ALL)
             .await?;
-        let root_bounds = self.header.copc_info.root_bounds();
-
-        let keys: Vec<VoxelKey> = self
-            .hierarchy
-            .iter()
-            .filter(|(k, e)| {
-                e.point_count > 0
-                    && k.level <= max_level
-                    && k.bounds(&root_bounds).intersects(bounds)
-            })
-            .map(|(k, _)| *k)
-            .collect();
-
-        let mut all_points = Vec::new();
-        for key in keys {
-            let chunk = self.fetch_chunk(&key).await?;
-            let points = self.read_points_in_bounds(&chunk, bounds)?;
-            all_points.extend(points);
+        let mut out = Vec::new();
+        for chunk in &chunks {
+            let indices = chunk
+                .indices_in_bounds(bounds)
+                .expect("Fields::ALL includes Fields::Z");
+            if indices.is_empty() {
+                continue;
+            }
+            out.extend(chunk.points_at(&indices)?);
         }
-        Ok(all_points)
+        Ok(out)
     }
-}
-
-/// Filter points to only those inside an axis-aligned bounding box.
-pub fn filter_points_by_bounds(
-    points: Vec<las::Point>,
-    bounds: &crate::types::Aabb,
-) -> Vec<las::Point> {
-    points
-        .into_iter()
-        .filter(|p| {
-            p.x >= bounds.min[0]
-                && p.x <= bounds.max[0]
-                && p.y >= bounds.min[1]
-                && p.y <= bounds.max[1]
-                && p.z >= bounds.min[2]
-                && p.z <= bounds.max[2]
-        })
-        .collect()
 }

--- a/copc-streaming/src/reader.rs
+++ b/copc-streaming/src/reader.rs
@@ -97,6 +97,12 @@ impl<S: ByteSource> CopcStreamingReader<S> {
         self.hierarchy.has_pending_pages()
     }
 
+    /// Iterate the [`VoxelKey`]s anchoring the currently-pending hierarchy
+    /// pages. See [`HierarchyCache::pending_page_keys`](crate::HierarchyCache::pending_page_keys).
+    pub fn pending_page_keys(&self) -> impl Iterator<Item = VoxelKey> + '_ {
+        self.hierarchy.pending_page_keys()
+    }
+
     // --- Hierarchy loading ---
 
     /// Load the next batch of pending hierarchy pages.

--- a/copc-streaming/src/reader.rs
+++ b/copc-streaming/src/reader.rs
@@ -190,6 +190,47 @@ impl<S: ByteSource> CopcStreamingReader<S> {
         .await
     }
 
+    /// Fetch and decompress multiple chunks in one batched I/O call.
+    ///
+    /// Uses [`ByteSource::read_ranges`] to coalesce the fetches — HTTP
+    /// sources that override `read_ranges` with parallel requests or
+    /// range merging will issue far fewer round-trips than calling
+    /// [`fetch_chunk`](Self::fetch_chunk) in a loop.
+    ///
+    /// All keys must already be present in the loaded hierarchy; call
+    /// one of the `load_hierarchy_*` methods first.
+    pub async fn fetch_chunks(
+        &self,
+        keys: &[VoxelKey],
+        fields: Fields,
+    ) -> Result<Vec<Chunk>, CopcError> {
+        let entries: Vec<&HierarchyEntry> = keys
+            .iter()
+            .map(|k| self.hierarchy.get(k).ok_or(CopcError::NodeNotFound(*k)))
+            .collect::<Result<_, _>>()?;
+
+        let ranges: Vec<(u64, u64)> = entries
+            .iter()
+            .map(|e| (e.offset, e.byte_size as u64))
+            .collect();
+
+        let compressed_blobs = self.source.read_ranges(&ranges).await?;
+
+        compressed_blobs
+            .iter()
+            .zip(entries.iter())
+            .map(|(data, entry)| {
+                chunk::decompress_chunk(
+                    data,
+                    entry,
+                    &self.header.laz_vlr,
+                    &self.header.las_header,
+                    fields,
+                )
+            })
+            .collect()
+    }
+
     /// Keys in the currently-loaded hierarchy whose subtree intersects
     /// `bounds` and whose level is at most `max_level` (if provided).
     ///
@@ -223,10 +264,8 @@ impl<S: ByteSource> CopcStreamingReader<S> {
     /// Load hierarchy for `bounds`, fetch every intersecting chunk, and
     /// return them.
     ///
-    /// Convenience wrapper over [`load_hierarchy_for_bounds`](Self::load_hierarchy_for_bounds),
-    /// [`visible_keys`](Self::visible_keys), and [`fetch_chunk`](Self::fetch_chunk)
-    /// in a sequential loop. For parallel fetches, cancellation, or
-    /// prioritization, use those building blocks directly.
+    /// Uses [`fetch_chunks`](Self::fetch_chunks) to batch all chunk
+    /// fetches into a single [`ByteSource::read_ranges`] call.
     pub async fn query_chunks(
         &mut self,
         bounds: &crate::types::Aabb,
@@ -234,11 +273,7 @@ impl<S: ByteSource> CopcStreamingReader<S> {
     ) -> Result<Vec<Chunk>, CopcError> {
         self.load_hierarchy_for_bounds(bounds).await?;
         let keys = self.visible_keys(bounds, None);
-        let mut chunks = Vec::with_capacity(keys.len());
-        for key in keys {
-            chunks.push(self.fetch_chunk(&key, fields).await?);
-        }
-        Ok(chunks)
+        self.fetch_chunks(&keys, fields).await
     }
 
     /// Same as [`query_chunks`](Self::query_chunks) but limits the octree
@@ -252,11 +287,7 @@ impl<S: ByteSource> CopcStreamingReader<S> {
         self.load_hierarchy_for_bounds_to_level(bounds, max_level)
             .await?;
         let keys = self.visible_keys(bounds, Some(max_level));
-        let mut chunks = Vec::with_capacity(keys.len());
-        for key in keys {
-            chunks.push(self.fetch_chunk(&key, fields).await?);
-        }
-        Ok(chunks)
+        self.fetch_chunks(&keys, fields).await
     }
 
     // ==================== Simple API (tier 1) ====================

--- a/copc-temporal/Cargo.toml
+++ b/copc-temporal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copc-temporal"
-version = "0.0.0-dev"
+version = "0.2.0-dev"
 edition = "2024"
 description = "COPC Temporal Index Extension reader for time-range filtering of point clouds"
 license = "MIT"
@@ -11,7 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 copc-streaming = { path = "../copc-streaming" }
-las = { version = "0.9", features = ["laz"] }
+las = { git = "https://github.com/jacovdbergh/las-rs", rev = "833cf7ae0d8e98edf41bca358dedb68297e23215", features = ["laz"] }
 byteorder = "1"
 thiserror = "2"
 [dev-dependencies]

--- a/copc-temporal/src/lib.rs
+++ b/copc-temporal/src/lib.rs
@@ -33,10 +33,45 @@
 //! ).await?;
 //! ```
 //!
+//! # Fast path: select only the fields you need
+//!
+//! [`TemporalCache::query_points`] decodes every field and materializes
+//! `las::Point` values. For hot paths,
+//! [`TemporalCache::query_chunks`] returns `(Chunk, candidate_range)`
+//! pairs with a caller-chosen [`Fields`](copc_streaming::Fields) mask and
+//! lets you walk columns directly. `candidate_range` is the sub-range of
+//! point indices within each chunk whose GPS times could possibly match
+//! `[start, end]` based on the temporal index stride samples — use it to
+//! skip points that are guaranteed not to match.
+//!
+//! ```rust,ignore
+//! use copc_streaming::Fields;
+//! use copc_temporal::indices_in_time_range;
+//!
+//! let chunks = temporal
+//!     .query_chunks(
+//!         &mut reader,
+//!         &my_query_box,
+//!         start,
+//!         end,
+//!         Fields::Z | Fields::GPS_TIME,
+//!     )
+//!     .await?;
+//!
+//! for (chunk, range) in &chunks {
+//!     // Narrow to the candidate range first, then filter exactly.
+//!     let precise: Vec<u32> = indices_in_time_range(chunk, start, end)
+//!         .unwrap()
+//!         .into_iter()
+//!         .filter(|&i| (range.start..range.end).contains(&i))
+//!         .collect();
+//!     // ... walk chunk.positions() / chunk.gps_time() at these indices
+//! }
+//! ```
+//!
 //! # Low-level access
 //!
-//! For full control over page loading and chunk processing, use the building
-//! blocks directly:
+//! For full control over page loading, use the building blocks directly:
 //!
 //! ```rust,ignore
 //! // Load only temporal pages that overlap the time range.
@@ -54,11 +89,13 @@
 //! # How it works
 //!
 //! [`TemporalCache::from_reader`] loads the header and root page.
-//! [`TemporalCache::query_points`] then loads the relevant hierarchy and
-//! temporal pages, fetches matching chunks, and returns only the points
-//! that fall inside both the bounding box and time window.
+//! [`TemporalCache::query_chunks`] / [`TemporalCache::query_points`] then
+//! load the relevant hierarchy and temporal pages, fetch matching chunks,
+//! and return them (with candidate ranges) or the points inside both the
+//! bounding box and time window.
 //!
 //! For time-only queries (no spatial filter), use
+//! [`TemporalCache::query_chunks_by_time`] /
 //! [`TemporalCache::query_points_by_time`].
 //!
 //! For advanced use cases you can call [`TemporalCache::load_pages_for_time_range`]
@@ -79,11 +116,44 @@ pub use temporal_index::NodeTemporalEntry;
 // Re-export copc-streaming types that temporal consumers will need.
 pub use copc_streaming::{Aabb, ByteSource, VoxelKey};
 
+/// Indices of points whose GPS time falls within `[start, end]`.
+///
+/// Returns `None` if the chunk was not decoded with
+/// [`copc_streaming::Fields::GPS_TIME`] or the underlying format does not
+/// include GPS time. Pair the returned indices with any other column
+/// iterator on the chunk to build a filtered view without materializing
+/// `las::Point` values.
+///
+/// ```rust,ignore
+/// use copc_streaming::Fields;
+///
+/// let chunk = reader.fetch_chunk(&key, Fields::Z | Fields::GPS_TIME).await?;
+/// let indices = copc_temporal::indices_in_time_range(&chunk, start, end)
+///     .expect("we asked for GPS_TIME");
+/// for &i in &indices {
+///     let p = chunk.point(i as usize);
+///     // ...
+/// }
+/// ```
+pub fn indices_in_time_range(
+    chunk: &copc_streaming::Chunk,
+    start: GpsTime,
+    end: GpsTime,
+) -> Option<Vec<u32>> {
+    let times = chunk.gps_time()?;
+    Some(
+        times
+            .enumerate()
+            .filter_map(|(i, t)| (t >= start.0 && t <= end.0).then_some(i as u32))
+            .collect(),
+    )
+}
+
 /// Filter points to only those whose GPS time falls within `[start, end]`.
 ///
-/// Points without a GPS time are excluded. Use after
-/// [`CopcStreamingReader::read_points_range`](copc_streaming::CopcStreamingReader::read_points_range)
-/// to trim points at the edges of an estimated temporal range.
+/// Points without a GPS time are excluded. Convenience for the simple
+/// `Vec<las::Point>` API; prefer [`indices_in_time_range`] on a
+/// [`copc_streaming::Chunk`] when you're already on the column-oriented path.
 pub fn filter_points_by_time(
     points: Vec<las::Point>,
     start: GpsTime,
@@ -93,4 +163,85 @@ pub fn filter_points_by_time(
         .into_iter()
         .filter(|p| p.gps_time.is_some_and(|t| t >= start.0 && t <= end.0))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use copc_streaming::{Chunk, Fields, VoxelKey};
+    use las::point::Format;
+    use las::raw::point::{Flags, ScanAngle};
+
+    fn build_test_cloud(n: i32) -> las::PointCloud {
+        let format = Format::new(7).unwrap();
+        let unit = las::Transform {
+            scale: 1.0,
+            offset: 0.0,
+        };
+        let transforms = las::Vector {
+            x: unit,
+            y: unit,
+            z: unit,
+        };
+        let mut buf = Vec::new();
+        for i in 0..n {
+            let rp = las::raw::Point {
+                x: i,
+                y: i,
+                z: i,
+                intensity: 0,
+                flags: Flags::ThreeByte(0, 0, 0),
+                scan_angle: ScanAngle::Scaled(0),
+                user_data: 0,
+                point_source_id: 0,
+                gps_time: Some(1000.0 + f64::from(i)),
+                color: Some(las::Color {
+                    red: 0,
+                    green: 0,
+                    blue: 0,
+                }),
+                waveform: None,
+                nir: None,
+                extra_bytes: Vec::new(),
+            };
+            rp.write_to(&mut buf, &format).unwrap();
+        }
+        las::PointCloud::from_raw_bytes(format, transforms, buf).unwrap()
+    }
+
+    fn make_chunk(cloud: las::PointCloud, fields: Fields) -> Chunk {
+        Chunk::new(VoxelKey::ROOT, fields, cloud)
+    }
+
+    #[test]
+    fn indices_in_time_range_returns_none_without_gps_time_field() {
+        let chunk = make_chunk(build_test_cloud(5), Fields::Z);
+        let r = indices_in_time_range(&chunk, GpsTime(1000.0), GpsTime(1003.0));
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn indices_in_time_range_filters_window() {
+        let chunk = make_chunk(build_test_cloud(5), Fields::ALL);
+        // gps times: 1000, 1001, 1002, 1003, 1004
+        let inside = indices_in_time_range(&chunk, GpsTime(1001.0), GpsTime(1003.0)).unwrap();
+        assert_eq!(inside, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn indices_in_time_range_empty_when_outside() {
+        let chunk = make_chunk(build_test_cloud(5), Fields::ALL);
+        let inside = indices_in_time_range(&chunk, GpsTime(9000.0), GpsTime(10000.0)).unwrap();
+        assert!(inside.is_empty());
+    }
+
+    #[test]
+    fn filter_points_by_time_excludes_none_gps_time() {
+        let p = las::Point {
+            gps_time: None,
+            ..Default::default()
+        };
+        let filtered = filter_points_by_time(vec![p], GpsTime(0.0), GpsTime(10.0));
+        assert!(filtered.is_empty());
+    }
 }

--- a/copc-temporal/src/temporal_cache.rs
+++ b/copc-temporal/src/temporal_cache.rs
@@ -312,14 +312,16 @@ impl TemporalCache {
             })
             .collect();
 
-        let mut out = Vec::with_capacity(matches.len());
-        for (key, range) in matches {
-            let chunk = reader
-                .fetch_chunk(&key, fields)
-                .await
-                .map_err(TemporalError::Copc)?;
-            out.push((chunk, range));
-        }
+        let keys: Vec<copc_streaming::VoxelKey> =
+            matches.iter().map(|(k, _)| *k).collect();
+        let chunks = reader
+            .fetch_chunks(&keys, fields)
+            .await
+            .map_err(TemporalError::Copc)?;
+        let out: Vec<_> = chunks
+            .into_iter()
+            .zip(matches.into_iter().map(|(_, range)| range))
+            .collect();
         Ok(out)
     }
 
@@ -359,14 +361,16 @@ impl TemporalCache {
             })
             .collect();
 
-        let mut out = Vec::with_capacity(matches.len());
-        for (key, range) in matches {
-            let chunk = reader
-                .fetch_chunk(&key, fields)
-                .await
-                .map_err(TemporalError::Copc)?;
-            out.push((chunk, range));
-        }
+        let keys: Vec<copc_streaming::VoxelKey> =
+            matches.iter().map(|(k, _)| *k).collect();
+        let chunks = reader
+            .fetch_chunks(&keys, fields)
+            .await
+            .map_err(TemporalError::Copc)?;
+        let out: Vec<_> = chunks
+            .into_iter()
+            .zip(matches.into_iter().map(|(_, range)| range))
+            .collect();
         Ok(out)
     }
 

--- a/copc-temporal/src/temporal_cache.rs
+++ b/copc-temporal/src/temporal_cache.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use copc_streaming::{ByteSource, CopcStreamingReader, VoxelKey};
+use copc_streaming::{ByteSource, Chunk, CopcStreamingReader, Fields, VoxelKey};
 
 use crate::TemporalError;
 use crate::gps_time::GpsTime;
@@ -232,40 +232,72 @@ impl TemporalCache {
         self.entries.iter()
     }
 
-    // --- High-level queries ---
+    // ==================== Fast API ====================
+    //
+    // Column-oriented queries that return `Chunk`s with a caller-chosen
+    // `Fields` mask, alongside an estimated candidate index range derived
+    // from the temporal index stride samples. Callers walk columns
+    // directly and decide for themselves whether to materialize
+    // `las::Point` values.
 
-    /// Query points by time range and spatial bounds.
+    /// Query chunks by time range and spatial bounds.
     ///
-    /// Loads the relevant hierarchy and temporal pages, fetches matching
-    /// chunks, and returns only the points that fall inside both the time
-    /// window and the bounding box.
+    /// Loads the relevant hierarchy and temporal pages, fetches every
+    /// matching chunk with the caller's `fields` mask, and returns
+    /// `(chunk, candidate_range)` pairs. `candidate_range` is the
+    /// sub-range of point indices in `chunk` whose GPS times could
+    /// possibly fall within `[start, end]` based on the temporal index
+    /// stride samples — points outside this range are guaranteed not to
+    /// match and can be skipped.
+    ///
+    /// The caller is responsible for the exact per-point intersection.
+    /// Combine with [`Chunk::indices_in_bounds`] and
+    /// [`indices_in_time_range`](crate::indices_in_time_range) to compute
+    /// the precise matching set, then walk column accessors or call
+    /// [`Chunk::points_at`] to materialize owned values.
     ///
     /// ```rust,ignore
-    /// let points = temporal.query_points(
-    ///     &mut reader, &query_box, start, end,
-    /// ).await?;
+    /// use copc_streaming::Fields;
+    ///
+    /// let chunks = temporal
+    ///     .query_chunks(
+    ///         &mut reader,
+    ///         &bbox,
+    ///         start,
+    ///         end,
+    ///         Fields::Z | Fields::GPS_TIME,
+    ///     )
+    ///     .await?;
+    ///
+    /// for (chunk, range) in &chunks {
+    ///     let times = chunk.gps_time().unwrap();
+    ///     for (i, t) in times.enumerate().skip(range.start as usize)
+    ///                                    .take(range.len()) {
+    ///         if t >= start.0 && t <= end.0 {
+    ///             // ...
+    ///         }
+    ///     }
+    /// }
     /// ```
-    pub async fn query_points<S: ByteSource>(
+    pub async fn query_chunks<S: ByteSource>(
         &mut self,
         reader: &mut CopcStreamingReader<S>,
         bounds: &copc_streaming::Aabb,
         start: GpsTime,
         end: GpsTime,
-    ) -> Result<Vec<las::Point>, TemporalError> {
-        // Load spatial hierarchy for the region.
+        fields: Fields,
+    ) -> Result<Vec<(Chunk, std::ops::Range<u32>)>, TemporalError> {
         reader
             .load_hierarchy_for_bounds(bounds)
             .await
             .map_err(TemporalError::Copc)?;
 
-        // Load temporal pages that overlap the time range.
         self.load_pages_for_time_range(reader.source(), start, end)
             .await?;
 
         let root_bounds = reader.copc_info().root_bounds();
         let stride = self.stride;
 
-        // Collect matching (key, point_range) pairs.
         let matches: Vec<_> = self
             .nodes_in_range(start, end)
             .into_iter()
@@ -280,31 +312,30 @@ impl TemporalCache {
             })
             .collect();
 
-        let mut all_points = Vec::new();
+        let mut out = Vec::with_capacity(matches.len());
         for (key, range) in matches {
             let chunk = reader
-                .fetch_chunk(&key)
+                .fetch_chunk(&key, fields)
                 .await
                 .map_err(TemporalError::Copc)?;
-            let points = reader
-                .read_points_range_in_bounds(&chunk, range, bounds)
-                .map_err(TemporalError::Copc)?;
-            let points = crate::filter_points_by_time(points, start, end);
-            all_points.extend(points);
+            out.push((chunk, range));
         }
-        Ok(all_points)
+        Ok(out)
     }
 
-    /// Query points by time range only (no spatial filtering).
+    /// Query chunks by time range only (no spatial filtering).
     ///
-    /// Loads all hierarchy pages and temporal pages that overlap the time
-    /// range, then returns points within the time window.
-    pub async fn query_points_by_time<S: ByteSource>(
+    /// Like [`query_chunks`](Self::query_chunks) but loads the full
+    /// hierarchy and skips the bounding-box intersection test. Returns
+    /// every chunk whose node temporal range overlaps `[start, end]`,
+    /// each paired with its candidate index range.
+    pub async fn query_chunks_by_time<S: ByteSource>(
         &mut self,
         reader: &mut CopcStreamingReader<S>,
         start: GpsTime,
         end: GpsTime,
-    ) -> Result<Vec<las::Point>, TemporalError> {
+        fields: Fields,
+    ) -> Result<Vec<(Chunk, std::ops::Range<u32>)>, TemporalError> {
         reader
             .load_all_hierarchy()
             .await
@@ -328,17 +359,113 @@ impl TemporalCache {
             })
             .collect();
 
-        let mut all_points = Vec::new();
+        let mut out = Vec::with_capacity(matches.len());
         for (key, range) in matches {
             let chunk = reader
-                .fetch_chunk(&key)
+                .fetch_chunk(&key, fields)
                 .await
                 .map_err(TemporalError::Copc)?;
-            let points = reader
-                .read_points_range(&chunk, range)
-                .map_err(TemporalError::Copc)?;
-            let points = crate::filter_points_by_time(points, start, end);
-            all_points.extend(points);
+            out.push((chunk, range));
+        }
+        Ok(out)
+    }
+
+    // ==================== Simple API ====================
+    //
+    // One-line entry points for the common case. Internally wrap the
+    // fast API with `Fields::ALL` and materialize matching points.
+
+    /// Query points by time range and spatial bounds.
+    ///
+    /// Loads the relevant hierarchy and temporal pages, fetches matching
+    /// chunks, and returns only the points that fall inside both the time
+    /// window and the bounding box.
+    ///
+    /// Thin wrapper over [`query_chunks`](Self::query_chunks) with
+    /// `Fields::ALL`. Prefer `query_chunks` when you don't need every
+    /// field materialized as `las::Point` values.
+    ///
+    /// ```rust,ignore
+    /// let points = temporal.query_points(
+    ///     &mut reader, &query_box, start, end,
+    /// ).await?;
+    /// ```
+    pub async fn query_points<S: ByteSource>(
+        &mut self,
+        reader: &mut CopcStreamingReader<S>,
+        bounds: &copc_streaming::Aabb,
+        start: GpsTime,
+        end: GpsTime,
+    ) -> Result<Vec<las::Point>, TemporalError> {
+        let chunks_with_ranges = self
+            .query_chunks(reader, bounds, start, end, Fields::ALL)
+            .await?;
+
+        let mut all_points = Vec::new();
+        for (chunk, range) in chunks_with_ranges {
+            // Zero-copy filter walk: inspect PointRef-level accessors in
+            // the candidate range and collect indices that match both the
+            // time window and the bounding box.
+            let start_idx = range.start as usize;
+            let end_idx = (range.end as usize).min(chunk.point_count());
+            let mut matching = Vec::with_capacity(end_idx - start_idx);
+            for i in start_idx..end_idx {
+                let p = chunk.cloud().point(i);
+                let Some(t) = p.gps_time() else {
+                    continue;
+                };
+                if t < start.0 || t > end.0 {
+                    continue;
+                }
+                let (x, y, z) = (p.x(), p.y(), p.z());
+                if x < bounds.min[0]
+                    || x > bounds.max[0]
+                    || y < bounds.min[1]
+                    || y > bounds.max[1]
+                    || z < bounds.min[2]
+                    || z > bounds.max[2]
+                {
+                    continue;
+                }
+                matching.push(i as u32);
+            }
+            all_points.extend(chunk.points_at(&matching)?);
+        }
+        Ok(all_points)
+    }
+
+    /// Query points by time range only (no spatial filtering).
+    ///
+    /// Loads all hierarchy pages and temporal pages that overlap the time
+    /// range, then returns points within the time window.
+    ///
+    /// Thin wrapper over [`query_chunks_by_time`](Self::query_chunks_by_time)
+    /// with `Fields::ALL`.
+    pub async fn query_points_by_time<S: ByteSource>(
+        &mut self,
+        reader: &mut CopcStreamingReader<S>,
+        start: GpsTime,
+        end: GpsTime,
+    ) -> Result<Vec<las::Point>, TemporalError> {
+        let chunks_with_ranges = self
+            .query_chunks_by_time(reader, start, end, Fields::ALL)
+            .await?;
+
+        let mut all_points = Vec::new();
+        for (chunk, range) in chunks_with_ranges {
+            let start_idx = range.start as usize;
+            let end_idx = (range.end as usize).min(chunk.point_count());
+            let mut matching = Vec::with_capacity(end_idx - start_idx);
+            for i in start_idx..end_idx {
+                let p = chunk.cloud().point(i);
+                let Some(t) = p.gps_time() else {
+                    continue;
+                };
+                if t >= start.0 && t <= end.0 {
+                    matching.push(i as u32);
+                }
+            }
+            all_points.extend(chunk.points_at(&matching)?);
         }
         Ok(all_points)
     }


### PR DESCRIPTION
## Summary

Replaces the old `DecompressedChunk` + `Vec<las::Point>` reader path with a column-oriented `Chunk` wrapping `las::PointCloud` (from gadomski/las-rs#143) and a `Fields` bitflag that drives `laz::DecompressionSelection` for layer-level selective decode. The point is to stop decoding layers nobody reads and stop materializing points we're just going to throw away.

Two-tier reader API:

- **Simple** — `fetch_points` / `query_points` / `query_points_to_level` return `Vec<las::Point>`. Unchanged shape for scripts and tests.
- **Fast** — `fetch_chunk` / `query_chunks` / `query_chunks_to_level` take a `Fields` mask and return `Chunk`s with zero-copy column access. Field accessors return `Option` so skipped fields can't silently read as zero.

`copc-temporal` mirrors the same split with `query_chunks` / `query_chunks_by_time` alongside the existing `query_points` variants.

Depends on the updated `jacovdbergh/las-rs` `point-cloud-api` branch (pinned to `833cf7a`). Bumps the workspace version to `0.2.0-dev` since `DecompressedChunk` and the old `read_points*` methods are gone.

## Before / after

Fetching only xyz + rgb for a bounding box:

```rust
// before — decoded every layer, materialized every point
let points = reader.query_points(&bbox).await?;
for p in &points {
    do_something(p.x, p.y, p.z, p.color);
}
```

```rust
// after — selective decode, zero-copy column walks
use copc_streaming::Fields;

let chunks = reader.query_chunks(&bbox, Fields::Z | Fields::RGB).await?;
for chunk in &chunks {
    let positions = chunk.positions().unwrap();
    let rgb = chunk.rgb().unwrap();
    for (pos, rgb) in positions.zip(rgb) {
        do_something(pos[0], pos[1], pos[2], Some(rgb));
    }
}
```

Temporal query that intersects a spatial and time window:

```rust
// before — materialized every point in the candidate range
let points = temporal.query_points(&mut reader, &bbox, start, end).await?;
```

```rust
// after (fast path) — walk columns, filter, materialize only matches
use copc_streaming::Fields;
use copc_temporal::indices_in_time_range;

let chunks = temporal
    .query_chunks(&mut reader, &bbox, start, end, Fields::Z | Fields::GPS_TIME)
    .await?;

for (chunk, candidate_range) in &chunks {
    let in_time = indices_in_time_range(chunk, start, end).unwrap();
    let in_bounds = chunk.indices_in_bounds(&bbox).unwrap();
    // intersect as you see fit, then walk the columns directly
}

// the simple `query_points` still works unchanged if you just want owned points
```

## Test plan

- `cargo build --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test --all` — 42 unit tests + 1 doctest pass
- `cargo doc --no-deps --all` — no warnings, no broken links
- `cargo semver-checks check-release -p copc-streaming -p copc-temporal` — passes against the 0.1.5 baseline
